### PR TITLE
chore(heliofi/react): Update package.json to ignore heliofi/react package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lerna": "^5.1.8"
   },
   "scripts": {
-    "release": "lerna publish",
+    "release": "lerna publish --ignore '@heliofi/react'",
     "build": "(yarn workspace @heliofi/solana-adapter run build) && (yarn workspace @heliofi/sdk run build) && (yarn workspace @heliofi/react run build)"
   },
   "workspaces": [


### PR DESCRIPTION
Deprecated the npm package
Updated package json to ignore the package in the future releases
Haven't tested but hopefully will be sufficient to not publish it anymore