### PR TITLE
chore(FUL-2903): security vulnerability: fix @solana/web3.js to 1.75.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   },
   "dependencies": {
     "http-cache-semantics": "^4.1.1"
+  },
+  "resolutions": {
+    "@solana/web3.js": "1.75.1"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,7 +25,7 @@
     "@heliofi/solana-adapter": "^4.0.2",
     "@project-serum/anchor": "^0.26.0",
     "@solana/wallet-adapter-react": "^0.15.20",
-    "@solana/web3.js": "^1.66.2",
+    "@solana/web3.js": "1.75.1",
     "bs58": "^5.0.0",
     "ethers": "^5.7.2",
     "jwt-decode": "^3.1.2",

--- a/packages/solana-adapter/package.json
+++ b/packages/solana-adapter/package.json
@@ -39,7 +39,7 @@
     "@sideway/formula": "^3.0.1",
     "@solana/spl-token": "^0.2.0",
     "@solana/wallet-adapter-react": "^0.15.20",
-    "@solana/web3.js": "^1.66.2",
+    "@solana/web3.js": "1.75.1",
     "bs58": "^5.0.0",
     "jsonwebtoken": "^9.0.0",
     "tweetnacl": "^1.0.3"

--- a/packages/solana-nft-adapter/package.json
+++ b/packages/solana-nft-adapter/package.json
@@ -39,7 +39,7 @@
     "@metaplex-foundation/mpl-token-metadata": "^2.12.0",
     "@solana/spl-token": "^0.3.7",
     "@solana/wallet-adapter-react": "^0.15.20",
-    "@solana/web3.js": "^1.68.0",
+    "@solana/web3.js": "1.75.1",
     "bs58": "^5.0.0",
     "tweetnacl": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,13 +1260,6 @@
   dependencies:
     "@noble/hashes" "1.3.2"
 
-"@noble/curves@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz"
-  integrity sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==
-  dependencies:
-    "@noble/hashes" "1.3.1"
-
 "@noble/ed25519@^1.7.0":
   version "1.7.3"
   resolved "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz"
@@ -1276,11 +1269,6 @@
   version "1.2.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz"
   integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
-
-"@noble/hashes@1.3.1", "@noble/hashes@^1.3.0":
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz"
-  integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
 
 "@noble/hashes@1.3.2":
   version "1.3.2"
@@ -2316,10 +2304,10 @@
     "@wallet-standard/app" "^1.0.1"
     "@wallet-standard/base" "^1.0.1"
 
-"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.44.0", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.70.1":
-  version "1.75.0"
-  resolved "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.75.0.tgz"
-  integrity sha512-rHQgdo1EWfb+nPUpHe4O7i8qJPELHKNR5PAZRK+a7XxiykqOfbaAlPt5boDWAGPnYbSv0ziWZv5mq9DlFaQCxg==
+"@solana/web3.js@1.75.1", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.44.0", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.70.1":
+  version "1.75.1"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.75.1.tgz#3a7c7f3b2f714aeeb6fcc84cc365dacb065d2c1f"
+  integrity sha512-QyoCRFalK38NdGM0mHJyJVpP7EKUlDgzbZiMtWlPGpTeueKppITCv3f1ahmYw/MxQM2os54WYGFUaN/ejtGpQA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@noble/ed25519" "^1.7.0"
@@ -2334,27 +2322,6 @@
     buffer "6.0.3"
     fast-stable-stringify "^1.0.0"
     jayson "^3.4.4"
-    node-fetch "^2.6.7"
-    rpc-websockets "^7.5.1"
-    superstruct "^0.14.2"
-
-"@solana/web3.js@^1.56.2":
-  version "1.77.3"
-  resolved "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.77.3.tgz"
-  integrity sha512-PHaO0BdoiQRPpieC1p31wJsBaxwIOWLh8j2ocXNKX8boCQVldt26Jqm2tZE4KlrvnCIV78owPLv1pEUgqhxZ3w==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@noble/curves" "^1.0.0"
-    "@noble/hashes" "^1.3.0"
-    "@solana/buffer-layout" "^4.0.0"
-    agentkeepalive "^4.2.1"
-    bigint-buffer "^1.1.5"
-    bn.js "^5.0.0"
-    borsh "^0.7.0"
-    bs58 "^4.0.1"
-    buffer "6.0.3"
-    fast-stable-stringify "^1.0.0"
-    jayson "^4.1.0"
     node-fetch "^2.6.7"
     rpc-websockets "^7.5.1"
     superstruct "^0.14.2"
@@ -6909,24 +6876,6 @@ jayson@^3.4.4:
     isomorphic-ws "^4.0.1"
     json-stringify-safe "^5.0.1"
     lodash "^4.17.20"
-    uuid "^8.3.2"
-    ws "^7.4.5"
-
-jayson@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/jayson/-/jayson-4.1.0.tgz"
-  integrity sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==
-  dependencies:
-    "@types/connect" "^3.4.33"
-    "@types/node" "^12.12.54"
-    "@types/ws" "^7.4.4"
-    JSONStream "^1.3.5"
-    commander "^2.20.3"
-    delay "^5.0.0"
-    es6-promisify "^5.0.0"
-    eyes "^0.1.8"
-    isomorphic-ws "^4.0.1"
-    json-stringify-safe "^5.0.1"
     uuid "^8.3.2"
     ws "^7.4.5"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dependency pinning in a core Solana client library could cause subtle runtime or build compatibility issues across adapters, despite being a targeted security fix.
> 
> **Overview**
> Pins `@solana/web3.js` to `1.75.1` across the monorepo to address a security vulnerability, including adding a root `resolutions` override to force the version.
> 
> Updates `@heliofi/sdk`, `@heliofi/solana-adapter`, and `@heliofi/solana-nft-adapter` to depend on the fixed version and refreshes `yarn.lock` to remove conflicting/older transitive entries (e.g., different `web3.js`/`jayson`/`@noble/*` resolutions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffc1ec329b126caf3ba141a0ed88d4a97e13d421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->